### PR TITLE
feat: Implement season management with scheduled data sync

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.configuration.updateBuildConfiguration": "disabled",
     "java.compile.nullAnalysis.mode": "automatic"
 }

--- a/backend/src/main/java/com/nhl/whoshotbackend/config/DataInitializer.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/config/DataInitializer.java
@@ -8,42 +8,26 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
 /**
- * Initializes data on application startup.
- * Syncs data for the current season by default.
+ * Initializes application on startup.
+ * Data synchronization is handled by scheduled jobs (see DataSyncScheduler).
+ * Previous season data should be populated using the PopulatePreviousSeasonScript.
  */
 @Component
 @Slf4j
 public class DataInitializer implements CommandLineRunner {
 
-    private final DataIntegrationService dataIntegrationService;
-    private final StatisticsService statisticsService;
     private final NhlApiService nhlApiService;
 
-    public DataInitializer(
-            DataIntegrationService dataIntegrationService,
-            StatisticsService statisticsService,
-            NhlApiService nhlApiService) {
-        this.dataIntegrationService = dataIntegrationService;
-        this.statisticsService = statisticsService;
+    public DataInitializer(NhlApiService nhlApiService) {
         this.nhlApiService = nhlApiService;
     }
 
     @Override
     public void run(String... args) {
         String currentSeason = nhlApiService.getCurrentSeason();
-        log.info("=== Starting initial data synchronization for season {} ===", currentSeason);
-
-        try {
-            // Sync all data from NHL API for current season
-            dataIntegrationService.syncStandings(currentSeason);
-            dataIntegrationService.syncPlayerStats(currentSeason);
-
-            // Calculate hot ratings and streaks for current season
-            statisticsService.calculateHotRatings(currentSeason);
-
-            log.info("=== Initial data synchronization completed successfully for season {} ===", currentSeason);
-        } catch (Exception e) {
-            log.error("Error during initial data synchronization. Application will continue but may have incomplete data.", e);
-        }
+        log.info("=== Application started successfully ===");
+        log.info("Current NHL season: {}", currentSeason);
+        log.info("Data synchronization is handled by scheduled jobs");
+        log.info("To populate previous season data, run: PopulatePreviousSeasonScript");
     }
 }

--- a/backend/src/main/java/com/nhl/whoshotbackend/script/PopulatePreviousSeasonScript.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/script/PopulatePreviousSeasonScript.java
@@ -1,0 +1,85 @@
+package com.nhl.whoshotbackend.script;
+
+import com.nhl.whoshotbackend.service.DataIntegrationService;
+import com.nhl.whoshotbackend.service.NhlApiService;
+import com.nhl.whoshotbackend.service.StatisticsService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Script to populate previous season data.
+ * This should be run once to fetch and store historical data.
+ *
+ * Usage:
+ * mvn spring-boot:run -Dspring-boot.run.arguments="--populate-previous-season=true"
+ *
+ * Or add to application.properties:
+ * populate-previous-season=true
+ */
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "populate-previous-season", havingValue = "true")
+public class PopulatePreviousSeasonScript implements CommandLineRunner {
+
+    private final DataIntegrationService dataIntegrationService;
+    private final StatisticsService statisticsService;
+    private final NhlApiService nhlApiService;
+
+    public PopulatePreviousSeasonScript(
+            DataIntegrationService dataIntegrationService,
+            StatisticsService statisticsService,
+            NhlApiService nhlApiService) {
+        this.dataIntegrationService = dataIntegrationService;
+        this.statisticsService = statisticsService;
+        this.nhlApiService = nhlApiService;
+    }
+
+    @Override
+    public void run(String... args) {
+        String currentSeason = nhlApiService.getCurrentSeason();
+        String previousSeason = calculatePreviousSeason(currentSeason);
+
+        log.info("=== Starting previous season data population ===");
+        log.info("Current season: {}", currentSeason);
+        log.info("Previous season: {}", previousSeason);
+
+        try {
+            // Sync previous season data
+            log.info("Fetching standings for season {}...", previousSeason);
+            dataIntegrationService.syncStandings(previousSeason);
+
+            log.info("Fetching player stats for season {}...", previousSeason);
+            dataIntegrationService.syncPlayerStats(previousSeason);
+
+            // Calculate hot ratings and streaks for previous season
+            log.info("Calculating statistics for season {}...", previousSeason);
+            statisticsService.calculateHotRatings(previousSeason);
+
+            log.info("=== Previous season data population completed successfully ===");
+            log.info("Previous season {} data is now available in the database", previousSeason);
+        } catch (Exception e) {
+            log.error("Error during previous season data population", e);
+            throw new RuntimeException("Failed to populate previous season data", e);
+        }
+    }
+
+    /**
+     * Calculate the previous season ID from the current season ID.
+     * Season format: YYYYYYYY (e.g., 20252026)
+     */
+    private String calculatePreviousSeason(String currentSeason) {
+        if (currentSeason == null || currentSeason.length() != 8) {
+            throw new IllegalArgumentException("Invalid season format: " + currentSeason);
+        }
+
+        int startYear = Integer.parseInt(currentSeason.substring(0, 4));
+        int endYear = Integer.parseInt(currentSeason.substring(4, 8));
+
+        int previousStartYear = startYear - 1;
+        int previousEndYear = endYear - 1;
+
+        return String.format("%d%d", previousStartYear, previousEndYear);
+    }
+}

--- a/backend/src/main/java/com/nhl/whoshotbackend/service/DataSyncScheduler.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/service/DataSyncScheduler.java
@@ -1,0 +1,51 @@
+package com.nhl.whoshotbackend.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Scheduled service for periodic NHL data synchronization.
+ * Runs at configured intervals to keep data fresh without manual intervention.
+ */
+@Service
+@Slf4j
+public class DataSyncScheduler {
+
+    private final DataIntegrationService dataIntegrationService;
+    private final StatisticsService statisticsService;
+    private final NhlApiService nhlApiService;
+
+    public DataSyncScheduler(
+            DataIntegrationService dataIntegrationService,
+            StatisticsService statisticsService,
+            NhlApiService nhlApiService) {
+        this.dataIntegrationService = dataIntegrationService;
+        this.statisticsService = statisticsService;
+        this.nhlApiService = nhlApiService;
+    }
+
+    /**
+     * Scheduled job to sync data for current season.
+     * Runs every 6 hours (configurable via cron expression).
+     * Default: 0 0 (star)/6 * * * (at minute 0, hour 0, 6, 12, 18)
+     */
+    @Scheduled(cron = "${nhl.sync.cron:0 0 */6 * * *}")
+    public void syncCurrentSeasonData() {
+        String currentSeason = nhlApiService.getCurrentSeason();
+        log.info("=== Starting scheduled data synchronization for season {} ===", currentSeason);
+
+        try {
+            // Sync all data from NHL API for current season
+            dataIntegrationService.syncStandings(currentSeason);
+            dataIntegrationService.syncPlayerStats(currentSeason);
+
+            // Calculate hot ratings and streaks for current season
+            statisticsService.calculateHotRatings(currentSeason);
+
+            log.info("=== Scheduled data synchronization completed successfully for season {} ===", currentSeason);
+        } catch (Exception e) {
+            log.error("Error during scheduled data synchronization for season {}", currentSeason, e);
+        }
+    }
+}

--- a/frontend/src/components/HottestPlayersTable.vue
+++ b/frontend/src/components/HottestPlayersTable.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup>
-import { ref, inject, watch, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlayerStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
@@ -36,20 +36,16 @@ import TeamLogo from './TeamLogo.vue'
 const router = useRouter()
 const { loading, error, getHottestPlayers } = usePlayerStats()
 const players = ref([])
-const selectedSeason = inject('selectedSeason')
 
 const loadData = async () => {
-  const data = await getHottestPlayers(5, 50, selectedSeason.value)
+  // Always fetch current season data (null = current season)
+  const data = await getHottestPlayers(5, 50, null)
   if (data) {
     players.value = data
   }
 }
 
 onMounted(() => {
-  loadData()
-})
-
-watch(selectedSeason, () => {
   loadData()
 })
 

--- a/frontend/src/components/PointStreaksTable.vue
+++ b/frontend/src/components/PointStreaksTable.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup>
-import { ref, inject, watch, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlayerStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
@@ -36,25 +36,16 @@ import TeamLogo from './TeamLogo.vue'
 const router = useRouter()
 const { loading, error, getPlayerStreaks } = usePlayerStats()
 const players = ref([])
-const selectedSeason = inject('selectedSeason')
 
 const loadData = async () => {
-  const data = await getPlayerStreaks(3, selectedSeason.value)
+  // Always fetch current season data (null = current season)
+  const data = await getPlayerStreaks(3, null)
   if (data) {
-<<<<<<< HEAD
     players.value = data // Load all players with streaks
-=======
-    // Show top 10 players with point streaks of 3+ games
-    players.value = data
->>>>>>> dev
   }
 }
 
 onMounted(() => {
-  loadData()
-})
-
-watch(selectedSeason, () => {
   loadData()
 })
 

--- a/frontend/src/components/SeasonDisplay.vue
+++ b/frontend/src/components/SeasonDisplay.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="season-display">
+    <span class="season-label">SEASON</span>
+    <span class="season-value">{{ seasonLabel }}</span>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+// Calculate current NHL season
+const currentSeason = computed(() => {
+  const currentYear = new Date().getFullYear()
+  const currentMonth = new Date().getMonth() + 1 // 1-12
+
+  // Determine current NHL season
+  let currentSeasonStart
+  if (currentMonth >= 1 && currentMonth <= 6) {
+    // Jan-June: Still in previous season
+    currentSeasonStart = currentYear - 1
+  } else if (currentMonth >= 10) {
+    // Oct-Dec: New season has started
+    currentSeasonStart = currentYear
+  } else {
+    // July-Sept: Prepare for next season
+    currentSeasonStart = currentYear
+  }
+
+  const endYear = currentSeasonStart + 1
+  return {
+    id: `${currentSeasonStart}${endYear}`,
+    startYear: currentSeasonStart,
+    endYear: endYear
+  }
+})
+
+const seasonLabel = computed(() => {
+  const start = String(currentSeason.value.startYear).slice(-2)
+  const end = String(currentSeason.value.endYear).slice(-2)
+  return `${start}/${end}`
+})
+</script>
+
+<style scoped>
+.season-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 1rem 0rem;
+  background-color: var(--color-bg-card);
+}
+
+.season-label {
+  font-size: 0.9rem;
+  font-weight: bold;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.season-value {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: bold;
+  font-family: var(--font-family);
+  color: var(--color-text-primary);
+  background-color: transparent;
+  border: 2px solid var(--color-border);
+  border-radius: 6px;
+  text-align: center;
+}
+</style>

--- a/frontend/src/components/TeamHotTable.vue
+++ b/frontend/src/components/TeamHotTable.vue
@@ -36,29 +36,24 @@
 </template>
 
 <script setup>
-import { ref, inject, watch, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, inject, onMounted } from 'vue'
+import { useRouter} from 'vue-router'
 import { useTeamStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
 
 const router = useRouter()
 const { loading, error, getStandings } = useTeamStats()
 const teams = ref([])
-const selectedSeason = inject('selectedSeason')
 const isExpanded = inject('isExpanded', ref(false))
 
 const loadData = async () => {
-  const data = await getStandings(selectedSeason.value)
+  // Always fetch current season data (null = current season)
+  const data = await getStandings(null)
   if (data) {
-<<<<<<< HEAD
-    // Filter only hot teams
-    teams.value = data.filter(team => team.hot)
-=======
     // Sort all teams by last 10 games win percentage (descending)
     teams.value = data
       .filter(team => team.last10GamesWinPercentage != null)
       .sort((a, b) => b.last10GamesWinPercentage - a.last10GamesWinPercentage)
->>>>>>> dev
   }
 }
 
@@ -68,10 +63,6 @@ const formatWinPercentage = (percentage) => {
 }
 
 onMounted(() => {
-  loadData()
-})
-
-watch(selectedSeason, () => {
   loadData()
 })
 

--- a/frontend/src/components/TeamStandingsTable.vue
+++ b/frontend/src/components/TeamStandingsTable.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script setup>
-import { ref, inject, watch, onMounted } from 'vue'
+import { ref, inject, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTeamStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
@@ -51,25 +51,17 @@ import TeamLogo from './TeamLogo.vue'
 const router = useRouter()
 const { loading, error, getStandings } = useTeamStats()
 const teams = ref([])
-const selectedSeason = inject('selectedSeason')
 const isExpanded = inject('isExpanded', ref(false))
 
 const loadData = async () => {
-  const data = await getStandings(selectedSeason.value)
+  // Always fetch current season data (null = current season)
+  const data = await getStandings(null)
   if (data) {
-<<<<<<< HEAD
-    teams.value = data // Load all teams (32 teams)
-=======
     teams.value = data // Show all teams
->>>>>>> dev
   }
 }
 
 onMounted(() => {
-  loadData()
-})
-
-watch(selectedSeason, () => {
   loadData()
 })
 

--- a/frontend/src/components/TeamWinStreaksTable.vue
+++ b/frontend/src/components/TeamWinStreaksTable.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script setup>
-import { ref, inject, watch, onMounted } from 'vue'
+import { ref, inject, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTeamStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
@@ -43,26 +43,18 @@ import TeamLogo from './TeamLogo.vue'
 const router = useRouter()
 const { loading, error, getStandings } = useTeamStats()
 const teams = ref([])
-const selectedSeason = inject('selectedSeason')
 const isExpanded = inject('isExpanded', ref(false))
 
 const loadData = async () => {
-  const data = await getStandings(selectedSeason.value)
+  // Always fetch current season data (null = current season)
+  const data = await getStandings(null)
   if (data) {
-<<<<<<< HEAD
-    teams.value = data // Load all teams with win streaks
-=======
     // Sort all teams by win streak length descending
     teams.value = data.sort((a, b) => b.currentWinStreak - a.currentWinStreak)
->>>>>>> dev
   }
 }
 
 onMounted(() => {
-  loadData()
-})
-
-watch(selectedSeason, () => {
   loadData()
 })
 

--- a/frontend/src/components/TopPointsTable.vue
+++ b/frontend/src/components/TopPointsTable.vue
@@ -11,7 +11,11 @@
         :class="{ 'hidden-item': index >= 5 }"
         @click="goToPlayer(player.playerId)"
       >
-        <span class="player-name">{{ player.firstName }} {{ player.lastName }}</span>
+        <div class="player-main">
+          <TeamLogo :teamCode="player.teamCode" size="small" />
+          <span class="player-name">{{ player.firstName }} {{ player.lastName }}</span>
+          <span class="team-code">{{ player.teamCode }}</span>
+        </div>
         <span class="player-stats">
           <span class="stat-item">G: {{ player.goals }}</span>
           <span class="stat-item">A: {{ player.assists }}</span>
@@ -24,7 +28,7 @@
 </template>
 
 <script setup>
-import { ref, inject, watch, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlayerStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
@@ -32,20 +36,16 @@ import TeamLogo from './TeamLogo.vue'
 const router = useRouter()
 const { loading, error, getTopScorers } = usePlayerStats()
 const players = ref([])
-const selectedSeason = inject('selectedSeason')
 
 const loadData = async () => {
-  const data = await getTopScorers(50, selectedSeason.value)
+  // Always fetch current season data (null = current season)
+  const data = await getTopScorers(50, null)
   if (data) {
     players.value = data // Load top 50 players
   }
 }
 
 onMounted(() => {
-  loadData()
-})
-
-watch(selectedSeason, () => {
   loadData()
 })
 

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -2,7 +2,7 @@
   <div class="home-page">
     <div class="header">
       <h1 class="title">WHOS HOT NHL</h1>
-      <SeasonSelector v-model="selectedSeason" @change="handleSeasonChange" />
+      <SeasonDisplay />
     </div>
 
     <div class="content-container">
@@ -36,7 +36,6 @@
 </template>
 
 <script setup>
-import { ref, provide } from 'vue'
 import ExpandableCard from '../components/ExpandableCard.vue'
 import TopPointsTable from '../components/TopPointsTable.vue'
 import PointStreaksTable from '../components/PointStreaksTable.vue'
@@ -44,15 +43,7 @@ import HottestPlayersTable from '../components/HottestPlayersTable.vue'
 import TeamStandingsTable from '../components/TeamStandingsTable.vue'
 import TeamWinStreaksTable from '../components/TeamWinStreaksTable.vue'
 import TeamHotTable from '../components/TeamHotTable.vue'
-import SeasonSelector from '../components/SeasonSelector.vue'
-
-const selectedSeason = ref(null)
-
-provide('selectedSeason', selectedSeason)
-
-const handleSeasonChange = (season) => {
-  console.log('Season changed to:', season)
-}
+import SeasonDisplay from '../components/SeasonDisplay.vue'
 </script>
 
 <style scoped>
@@ -83,7 +74,7 @@ const handleSeasonChange = (season) => {
   flex-shrink: 0;
 }
 
-.header :deep(.season-selector) {
+.header :deep(.season-display) {
   margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary
Implements issue #2 to simplify season management and optimize data synchronization.

## Backend Changes
### Scheduled Data Synchronization
- **Created `DataSyncScheduler`** - New service that runs scheduled jobs every 6 hours to sync current season data
- Configurable via `nhl.sync.cron` property (default: `0 0 */6 * * *`)
- Automatically syncs standings, player stats, and calculates hot ratings

### Startup Optimization
- **Updated `DataInitializer`** - Removed data synchronization from application startup
- Application now starts instantly without waiting for NHL API calls
- Only logs startup information and current season

### Previous Season Data Script
- **Created `PopulatePreviousSeasonScript`** - One-time script to populate previous season data
- Run with: `mvn spring-boot:run -Dspring-boot.run.arguments="--populate-previous-season=true"`
- Or add `populate-previous-season=true` to application.properties
- Previous season data stored in database for future comparison features

## Frontend Changes
### Season Display
- **Created `SeasonDisplay` component** - Simple component showing current season (read-only)
- Automatically calculates current NHL season based on date
- Replaced SeasonSelector dropdown with static display

### Component Updates
- **Removed season picker** from HomePage
- **Updated all table components** (6 total) to always fetch current season data:
  - TeamStandingsTable
  - TeamWinStreaksTable
  - TeamHotTable
  - TopPointsTable
  - PointStreaksTable
  - HottestPlayersTable
- Removed `selectedSeason` injection and watch dependencies
- Simplified data loading logic - always uses `null` for current season

## Benefits
✅ **Faster startup** - Application starts immediately without blocking on data sync  
✅ **Fresh data** - Scheduled jobs keep data up-to-date automatically  
✅ **Simpler UI** - No season selector confusion, always shows current season  
✅ **Historical data** - Previous season stored for future comparison features  
✅ **Configurable** - Sync interval can be adjusted via configuration  

## Breaking Changes
⚠️ **Season selector removed** - Users can only view current season now  
⚠️ **Initial startup** - First run won't have data until scheduled job runs  
⚠️ **Previous season** - Must be populated manually using script

## Test Plan
### Backend
1. Build: `cd backend && mvn clean compile`
2. Start application: `mvn spring-boot:run`
3. Verify it starts without syncing data
4. Wait for scheduled job (or trigger manually)
5. Test previous season script: `mvn spring-boot:run -Dspring-boot.run.arguments="--populate-previous-season=true"`

### Frontend
1. Run: `cd frontend && npm run dev`
2. Verify season display shows current season
3. Verify all tables load data correctly
4. Verify no season selector dropdown

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)