### PR TITLE
Debounce home search filter updates

### DIFF
--- a/API_CONTRACT.md
+++ b/API_CONTRACT.md
@@ -527,6 +527,39 @@ Get game-by-game results for a specific team in a given season.
 
 ---
 
+### 11. Global Search
+
+#### GET `/api/search`
+
+Search across players and teams for the current season.
+
+**Query Parameters:**
+- `query` (required, string) - Search term used to match player names, team names, or codes
+- `limit` (optional, integer, default: 10) - Maximum number of combined results to return
+- `season` (optional, string) - Season ID (defaults to current season)
+
+**Response:**
+```json
+[
+  {
+    "type": "player",
+    "id": "8478402",
+    "label": "Connor McDavid",
+    "subLabel": "EDM"
+  },
+  {
+    "type": "team",
+    "id": "EDM",
+    "label": "Edmonton Oilers",
+    "subLabel": "Pacific"
+  }
+]
+```
+
+`type` will be either `player` or `team`. `subLabel` provides supporting context such as the team code for players or the division/conference for teams.
+
+---
+
 ## Development Workflow
 
 1. **Backend develops endpoints** following this contract
@@ -561,3 +594,4 @@ Get game-by-game results for a specific team in a given season.
 
 - **1.0** (2025-10-14): Initial API contract
 - **1.1** (2025-10-25): Added player and team game log endpoints for graph visualization (Issue #3)
+- **1.2** (2025-11-05): Added global search endpoint for players and teams (Issue #4)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ cd /workspace/whos-hot-nhl && git pull
 ```
 
 **IMPORTANT**
-Never touch master branch.
+- Never touch master branch.
+- Changes intended for review should be committed on the `dev-review` branch before integration.
 
 ## VS Code Configuration
 

--- a/backend/src/main/java/com/nhl/whoshotbackend/controller/SearchController.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/controller/SearchController.java
@@ -1,0 +1,48 @@
+package com.nhl.whoshotbackend.controller;
+
+import com.nhl.whoshotbackend.dto.SearchResultDTO;
+import com.nhl.whoshotbackend.service.NhlApiService;
+import com.nhl.whoshotbackend.service.StatisticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST controller that exposes search endpoints for players and teams.
+ */
+@RestController
+@RequestMapping("/api/search")
+@Tag(name = "Search", description = "Search players and teams")
+@Slf4j
+@CrossOrigin(origins = "*")
+public class SearchController {
+
+    private final StatisticsService statisticsService;
+    private final NhlApiService nhlApiService;
+
+    public SearchController(StatisticsService statisticsService, NhlApiService nhlApiService) {
+        this.statisticsService = statisticsService;
+        this.nhlApiService = nhlApiService;
+    }
+
+    @GetMapping
+    @Operation(summary = "Search for players or teams", description = "Returns matching players and teams for the provided query")
+    public ResponseEntity<List<SearchResultDTO>> search(
+            @RequestParam String query,
+            @RequestParam(required = false) Integer limit,
+            @RequestParam(required = false) String season) {
+        String actualSeason = season != null ? season : nhlApiService.getCurrentSeason();
+        int effectiveLimit = limit != null ? limit : 10;
+        log.info("GET /api/search?query={}&season={}&limit={}", query, actualSeason, effectiveLimit);
+        List<SearchResultDTO> results = statisticsService.search(actualSeason, query, effectiveLimit);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/backend/src/main/java/com/nhl/whoshotbackend/dto/SearchResultDTO.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/dto/SearchResultDTO.java
@@ -1,0 +1,12 @@
+package com.nhl.whoshotbackend.dto;
+
+/**
+ * DTO representing a generic search result entry that can be a player or a team.
+ */
+public record SearchResultDTO(
+        String type,
+        String id,
+        String label,
+        String subLabel
+) {
+}

--- a/backend/src/main/java/com/nhl/whoshotbackend/repository/PlayerRepository.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/repository/PlayerRepository.java
@@ -1,8 +1,10 @@
 package com.nhl.whoshotbackend.repository;
 
 import com.nhl.whoshotbackend.entity.Player;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -35,4 +37,20 @@ public interface PlayerRepository extends JpaRepository<Player, Player.PlayerKey
      * Find players by team code for a specific season.
      */
     List<Player> findByTeamCodeAndSeason(String teamCode, String season);
+
+    /**
+     * Search players by name or team code for a season.
+     */
+    @Query("""
+            SELECT p FROM Player p
+            WHERE p.season = :season
+              AND (
+                    LOWER(p.fullName) LIKE LOWER(CONCAT('%', :query, '%'))
+                 OR LOWER(p.firstName) LIKE LOWER(CONCAT('%', :query, '%'))
+                 OR LOWER(p.lastName) LIKE LOWER(CONCAT('%', :query, '%'))
+                 OR LOWER(p.teamCode) LIKE LOWER(CONCAT('%', :query, '%'))
+              )
+            ORDER BY LOWER(p.lastName), LOWER(p.firstName)
+            """)
+    List<Player> searchPlayers(@Param("query") String query, @Param("season") String season, Pageable pageable);
 }

--- a/backend/src/main/java/com/nhl/whoshotbackend/repository/TeamRepository.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/repository/TeamRepository.java
@@ -1,8 +1,10 @@
 package com.nhl.whoshotbackend.repository;
 
 import com.nhl.whoshotbackend.entity.Team;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -36,4 +38,19 @@ public interface TeamRepository extends JpaRepository<Team, Team.TeamKey> {
      */
     @Query("SELECT t FROM Team t WHERE t.season = ?1 AND t.currentLossStreak > 0 ORDER BY t.currentLossStreak DESC")
     List<Team> findTeamsWithLossStreaks(String season);
+
+    /**
+     * Search teams by name, franchise, or code for a season.
+     */
+    @Query("""
+            SELECT t FROM Team t
+            WHERE t.season = :season
+              AND (
+                    LOWER(t.teamName) LIKE LOWER(CONCAT('%', :query, '%'))
+                 OR LOWER(t.franchiseName) LIKE LOWER(CONCAT('%', :query, '%'))
+                 OR LOWER(t.teamCode) LIKE LOWER(CONCAT('%', :query, '%'))
+              )
+            ORDER BY LOWER(t.teamName)
+            """)
+    List<Team> searchTeams(@Param("query") String query, @Param("season") String season, Pageable pageable);
 }

--- a/backend/src/main/java/com/nhl/whoshotbackend/service/StatisticsService.java
+++ b/backend/src/main/java/com/nhl/whoshotbackend/service/StatisticsService.java
@@ -1,6 +1,7 @@
 package com.nhl.whoshotbackend.service;
 
 import com.nhl.whoshotbackend.dto.GameLogDTO;
+import com.nhl.whoshotbackend.dto.SearchResultDTO;
 import com.nhl.whoshotbackend.dto.TeamGameLogDTO;
 import com.nhl.whoshotbackend.entity.GameLog;
 import com.nhl.whoshotbackend.entity.Player;
@@ -11,9 +12,12 @@ import com.nhl.whoshotbackend.repository.PlayerRepository;
 import com.nhl.whoshotbackend.repository.TeamGameRepository;
 import com.nhl.whoshotbackend.repository.TeamRepository;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -105,6 +109,48 @@ public class StatisticsService {
      */
     public List<Player> getTeamPlayers(String teamCode, String season) {
         return playerRepository.findByTeamCodeAndSeason(teamCode, season);
+    }
+
+    /**
+     * Search players and teams for a given season.
+     */
+    public List<SearchResultDTO> search(String season, String query, int limit) {
+        if (query == null || query.isBlank()) {
+            return List.of();
+        }
+
+        String normalizedQuery = query.trim();
+        int effectiveLimit = Math.max(1, limit);
+        Pageable pageable = PageRequest.of(0, effectiveLimit);
+
+        List<SearchResultDTO> results = new ArrayList<>();
+
+        playerRepository.searchPlayers(normalizedQuery, season, pageable)
+                .forEach(player -> {
+                    String label = player.getFullName() != null && !player.getFullName().isBlank()
+                            ? player.getFullName()
+                            : (player.getFirstName() + " " + player.getLastName()).trim();
+                    results.add(new SearchResultDTO(
+                            "player",
+                            String.valueOf(player.getPlayerId()),
+                            label,
+                            player.getTeamCode()
+                    ));
+                });
+
+        teamRepository.searchTeams(normalizedQuery, season, pageable)
+                .forEach(team -> results.add(new SearchResultDTO(
+                        "team",
+                        team.getTeamCode(),
+                        team.getTeamName(),
+                        team.getDivisionName() != null ? team.getDivisionName() : team.getConferenceName()
+                )));
+
+        if (results.size() <= effectiveLimit) {
+            return results;
+        }
+
+        return results.subList(0, effectiveLimit);
     }
 
     /**

--- a/frontend/src/components/HottestPlayersTable.vue
+++ b/frontend/src/components/HottestPlayersTable.vue
@@ -2,10 +2,10 @@
   <div class="player-list">
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="players.length === 0" class="empty">No hot players</div>
+    <div v-else-if="filteredPlayers.length === 0" class="empty">No hot players</div>
     <div v-else class="players-grid">
       <div
-        v-for="player in players"
+        v-for="player in filteredPlayers"
         :key="player.playerId"
         class="player-item"
         @click="goToPlayer(player.playerId)"
@@ -27,10 +27,17 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlayerStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
+
+const props = defineProps({
+  searchTerm: {
+    type: String,
+    default: ''
+  }
+})
 
 const router = useRouter()
 const { loading, error, getHottestPlayers } = usePlayerStats()
@@ -45,6 +52,30 @@ const loadData = async () => {
 
 onMounted(() => {
   loadData()
+})
+
+const normalizedIncludes = (value, term) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  return value.toString().toLowerCase().includes(term)
+}
+
+const filteredPlayers = computed(() => {
+  const term = props.searchTerm?.trim().toLowerCase()
+  if (!term) {
+    return players.value
+  }
+
+  return players.value.filter((player) => {
+    const fullName = `${player.firstName ?? ''} ${player.lastName ?? ''}`.trim()
+    return (
+      normalizedIncludes(player.firstName, term) ||
+      normalizedIncludes(player.lastName, term) ||
+      normalizedIncludes(fullName, term) ||
+      normalizedIncludes(player.teamCode, term)
+    )
+  })
 })
 
 const goToPlayer = (playerId) => {

--- a/frontend/src/components/PointStreaksTable.vue
+++ b/frontend/src/components/PointStreaksTable.vue
@@ -2,10 +2,10 @@
   <div class="player-list">
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="players.length === 0" class="empty">No point streaks</div>
+    <div v-else-if="filteredPlayers.length === 0" class="empty">No point streaks</div>
     <div v-else class="players-grid">
       <div
-        v-for="player in players"
+        v-for="player in filteredPlayers"
         :key="player.playerId"
         class="player-item"
         @click="goToPlayer(player.playerId)"
@@ -27,10 +27,17 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlayerStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
+
+const props = defineProps({
+  searchTerm: {
+    type: String,
+    default: ''
+  }
+})
 
 const router = useRouter()
 const { loading, error, getPlayerStreaks } = usePlayerStats()
@@ -46,6 +53,30 @@ const loadData = async () => {
 
 onMounted(() => {
   loadData()
+})
+
+const normalizedIncludes = (value, term) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  return value.toString().toLowerCase().includes(term)
+}
+
+const filteredPlayers = computed(() => {
+  const term = props.searchTerm?.trim().toLowerCase()
+  if (!term) {
+    return players.value
+  }
+
+  return players.value.filter((player) => {
+    const fullName = `${player.firstName ?? ''} ${player.lastName ?? ''}`.trim()
+    return (
+      normalizedIncludes(player.firstName, term) ||
+      normalizedIncludes(player.lastName, term) ||
+      normalizedIncludes(fullName, term) ||
+      normalizedIncludes(player.teamCode, term)
+    )
+  })
 })
 
 const goToPlayer = (playerId) => {

--- a/frontend/src/components/TeamHotTable.vue
+++ b/frontend/src/components/TeamHotTable.vue
@@ -2,10 +2,10 @@
   <div class="team-list">
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="teams.length === 0" class="empty">No hot teams</div>
+    <div v-else-if="filteredTeams.length === 0" class="empty">No hot teams</div>
     <div v-else class="teams-grid">
       <div
-        v-for="(team, index) in teams"
+        v-for="(team, index) in filteredTeams"
         :key="team.teamCode"
         class="team-item"
         @click="goToTeam(team.teamCode)"
@@ -35,10 +35,17 @@
 </template>
 
 <script setup>
-import { ref, inject, onMounted } from 'vue'
+import { ref, inject, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTeamStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
+
+const props = defineProps({
+  searchTerm: {
+    type: String,
+    default: ''
+  }
+})
 
 const router = useRouter()
 const { loading, error, getStandings } = useTeamStats()
@@ -51,7 +58,7 @@ const loadData = async () => {
     // Sort all teams by last 10 games win percentage (descending)
     teams.value = data
       .filter(team => team.last10GamesWinPercentage != null)
-      .sort((a, b) => b.last10GamesWinPercentage - a.last10GamesWinPercentage)
+      .sort((a, b) => (b.last10GamesWinPercentage ?? 0) - (a.last10GamesWinPercentage ?? 0))
   }
 }
 
@@ -62,6 +69,25 @@ const formatWinPercentage = (percentage) => {
 
 onMounted(() => {
   loadData()
+})
+
+const normalizedIncludes = (value, term) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  return value.toString().toLowerCase().includes(term)
+}
+
+const filteredTeams = computed(() => {
+  const term = props.searchTerm?.trim().toLowerCase()
+  if (!term) {
+    return teams.value
+  }
+
+  return teams.value.filter((team) => {
+    const searchable = [team.teamName, team.teamCode, team.franchiseName]
+    return searchable.some((value) => normalizedIncludes(value, term))
+  })
 })
 
 const goToTeam = (teamCode) => {

--- a/frontend/src/components/TeamStandingsTable.vue
+++ b/frontend/src/components/TeamStandingsTable.vue
@@ -2,10 +2,10 @@
   <div class="team-list">
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="teams.length === 0" class="empty">No teams found</div>
+    <div v-else-if="filteredTeams.length === 0" class="empty">No teams found</div>
     <div v-else class="teams-grid">
       <div
-        v-for="(team, index) in teams"
+        v-for="(team, index) in filteredTeams"
         :key="team.teamCode"
         class="team-item"
         @click="goToTeam(team.teamCode)"
@@ -42,10 +42,17 @@
 </template>
 
 <script setup>
-import { ref, inject, onMounted } from 'vue'
+import { ref, inject, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTeamStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
+
+const props = defineProps({
+  searchTerm: {
+    type: String,
+    default: ''
+  }
+})
 
 const router = useRouter()
 const { loading, error, getStandings } = useTeamStats()
@@ -61,6 +68,32 @@ const loadData = async () => {
 
 onMounted(() => {
   loadData()
+})
+
+const normalizedIncludes = (value, term) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  return value.toString().toLowerCase().includes(term)
+}
+
+const filteredTeams = computed(() => {
+  const term = props.searchTerm?.trim().toLowerCase()
+  if (!term) {
+    return teams.value
+  }
+
+  return teams.value.filter((team) => {
+    const searchable = [
+      team.teamName,
+      team.teamCode,
+      team.franchiseName,
+      team.divisionName,
+      team.conferenceName
+    ]
+
+    return searchable.some((value) => normalizedIncludes(value, term))
+  })
 })
 
 const goToTeam = (teamCode) => {

--- a/frontend/src/components/TeamWinStreaksTable.vue
+++ b/frontend/src/components/TeamWinStreaksTable.vue
@@ -2,10 +2,10 @@
   <div class="team-list">
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="teams.length === 0" class="empty">No win streaks found</div>
+    <div v-else-if="filteredTeams.length === 0" class="empty">No win streaks found</div>
     <div v-else class="teams-grid">
       <div
-        v-for="(team, index) in teams"
+        v-for="(team, index) in filteredTeams"
         :key="team.teamCode"
         class="team-item"
         @click="goToTeam(team.teamCode)"
@@ -34,10 +34,17 @@
 </template>
 
 <script setup>
-import { ref, inject, onMounted } from 'vue'
+import { ref, inject, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTeamStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
+
+const props = defineProps({
+  searchTerm: {
+    type: String,
+    default: ''
+  }
+})
 
 const router = useRouter()
 const { loading, error, getStandings } = useTeamStats()
@@ -48,12 +55,31 @@ const loadData = async () => {
   const data = await getStandings()
   if (data) {
     // Sort all teams by win streak length descending
-    teams.value = data.sort((a, b) => b.currentWinStreak - a.currentWinStreak)
+    teams.value = [...data].sort((a, b) => (b.currentWinStreak ?? 0) - (a.currentWinStreak ?? 0))
   }
 }
 
 onMounted(() => {
   loadData()
+})
+
+const normalizedIncludes = (value, term) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  return value.toString().toLowerCase().includes(term)
+}
+
+const filteredTeams = computed(() => {
+  const term = props.searchTerm?.trim().toLowerCase()
+  if (!term) {
+    return teams.value
+  }
+
+  return teams.value.filter((team) => {
+    const searchable = [team.teamName, team.teamCode, team.franchiseName]
+    return searchable.some((value) => normalizedIncludes(value, term))
+  })
 })
 
 const goToTeam = (teamCode) => {

--- a/frontend/src/components/TopPointsTable.vue
+++ b/frontend/src/components/TopPointsTable.vue
@@ -2,10 +2,10 @@
   <div class="player-list">
     <div v-if="loading" class="loading">Loading...</div>
     <div v-else-if="error" class="error">{{ error }}</div>
-    <div v-else-if="players.length === 0" class="empty">No players found</div>
+    <div v-else-if="filteredPlayers.length === 0" class="empty">No players found</div>
     <div v-else class="players-grid">
       <div
-        v-for="player in players"
+        v-for="player in filteredPlayers"
         :key="player.playerId"
         class="player-item"
         @click="goToPlayer(player.playerId)"
@@ -27,10 +27,17 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { usePlayerStats } from '../composables/useApi'
 import TeamLogo from './TeamLogo.vue'
+
+const props = defineProps({
+  searchTerm: {
+    type: String,
+    default: ''
+  }
+})
 
 const router = useRouter()
 const { loading, error, getTopScorers } = usePlayerStats()
@@ -45,6 +52,30 @@ const loadData = async () => {
 
 onMounted(() => {
   loadData()
+})
+
+const normalizedIncludes = (value, term) => {
+  if (value === null || value === undefined) {
+    return false
+  }
+  return value.toString().toLowerCase().includes(term)
+}
+
+const filteredPlayers = computed(() => {
+  const term = props.searchTerm?.trim().toLowerCase()
+  if (!term) {
+    return players.value
+  }
+
+  return players.value.filter((player) => {
+    const fullName = `${player.firstName ?? ''} ${player.lastName ?? ''}`.trim()
+    return (
+      normalizedIncludes(player.firstName, term) ||
+      normalizedIncludes(player.lastName, term) ||
+      normalizedIncludes(fullName, term) ||
+      normalizedIncludes(player.teamCode, term)
+    )
+  })
 })
 
 const goToPlayer = (playerId) => {

--- a/frontend/src/composables/useApi.js
+++ b/frontend/src/composables/useApi.js
@@ -115,3 +115,22 @@ export function useTeamStats() {
     getTeamGameLog
   }
 }
+
+export function useSearch() {
+  const { loading, error, fetchData } = useApi()
+
+  const search = async (query, limit = 10) => {
+    const params = new URLSearchParams({ query })
+    if (limit != null) {
+      params.append('limit', limit.toString())
+    }
+    const data = await fetchData(`/search?${params.toString()}`)
+    return data || []
+  }
+
+  return {
+    loading,
+    error,
+    search
+  }
+}

--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,34 +1,85 @@
 <template>
   <div class="home-page">
     <div class="header">
-      <h1 class="title">WHOS HOT NHL</h1>
-      <CurrentSeasonDisplay />
+      <div class="brand-block">
+        <h1 class="title">WHOS HOT NHL</h1>
+        <CurrentSeasonDisplay />
+      </div>
+
+      <div class="search-area">
+        <div class="search-input-wrapper" :class="{ active: showSuggestions }">
+          <input
+            v-model="searchQuery"
+            type="search"
+            class="search-input"
+            placeholder="Search players or teams"
+            @keydown.enter.prevent="applyFilterImmediately"
+            @keydown.esc.prevent="closeSuggestions"
+            @focus="handleFocus"
+            @blur="handleBlur"
+          />
+          <button
+            v-if="searchQuery"
+            class="clear-input"
+            type="button"
+            aria-label="Clear search"
+            @mousedown.prevent
+            @click="clearQuery"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div v-if="showSuggestions" class="search-suggestions" @mousedown.prevent>
+          <div v-if="searchLoading" class="suggestion-state">Searching…</div>
+          <div v-else-if="searchError" class="suggestion-state suggestion-error">{{ searchError }}</div>
+          <template v-else>
+            <div v-if="suggestions.length === 0" class="suggestion-state suggestion-empty">No matches found</div>
+            <ul v-else class="suggestion-list">
+              <li
+                v-for="option in suggestions"
+                :key="`${option.type}-${option.id}`"
+                class="suggestion-item"
+                @click="selectSuggestion(option)"
+              >
+                <span class="suggestion-label">{{ option.label }}</span>
+                <span class="suggestion-meta">{{ formatSuggestionMeta(option) }}</span>
+              </li>
+            </ul>
+          </template>
+        </div>
+      </div>
     </div>
 
     <div class="content-container">
+      <div v-if="hasActiveFilter" class="filter-banner">
+        <span>Filtering dashboard for “<strong>{{ activeFilter }}</strong>”.</span>
+        <button type="button" class="filter-clear" @click="clearFilter">Clear filter</button>
+      </div>
+
       <div class="cards-grid">
         <ExpandableCard title="Player standings">
-          <TopPointsTable />
+          <TopPointsTable :search-term="activeFilter" />
         </ExpandableCard>
 
         <ExpandableCard title="Point streaks">
-          <PointStreaksTable />
+          <PointStreaksTable :search-term="activeFilter" />
         </ExpandableCard>
 
         <ExpandableCard title="Whos hot">
-          <HottestPlayersTable />
+          <HottestPlayersTable :search-term="activeFilter" />
         </ExpandableCard>
 
         <ExpandableCard title="Team standings">
-          <TeamStandingsTable />
+          <TeamStandingsTable :search-term="activeFilter" />
         </ExpandableCard>
 
         <ExpandableCard title="Win streaks">
-          <TeamWinStreaksTable />
+          <TeamWinStreaksTable :search-term="activeFilter" />
         </ExpandableCard>
 
         <ExpandableCard title="Last 10 games">
-          <TeamHotTable />
+          <TeamHotTable :search-term="activeFilter" />
         </ExpandableCard>
       </div>
     </div>
@@ -36,6 +87,8 @@
 </template>
 
 <script setup>
+import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { useRouter } from 'vue-router'
 import ExpandableCard from '../components/ExpandableCard.vue'
 import TopPointsTable from '../components/TopPointsTable.vue'
 import PointStreaksTable from '../components/PointStreaksTable.vue'
@@ -44,6 +97,142 @@ import TeamStandingsTable from '../components/TeamStandingsTable.vue'
 import TeamWinStreaksTable from '../components/TeamWinStreaksTable.vue'
 import TeamHotTable from '../components/TeamHotTable.vue'
 import CurrentSeasonDisplay from '../components/CurrentSeasonDisplay.vue'
+import { useSearch } from '../composables/useApi'
+
+const router = useRouter()
+
+const searchQuery = ref('')
+const activeFilter = ref('')
+const suggestions = ref([])
+const isFocused = ref(false)
+const { loading: searchLoading, error: searchError, search: runSearch } = useSearch()
+
+let suggestionDebounceId = null
+let filterDebounceId = null
+let blurTimeoutId = null
+
+watch(searchQuery, (newValue) => {
+  if (suggestionDebounceId) {
+    clearTimeout(suggestionDebounceId)
+  }
+
+  const term = newValue.trim()
+
+  if (term.length < 2) {
+    suggestions.value = []
+    return
+  }
+
+  const pendingTerm = term
+
+  suggestionDebounceId = setTimeout(async () => {
+    const results = await runSearch(pendingTerm, 8)
+    if (searchQuery.value.trim() === pendingTerm) {
+      suggestions.value = results ?? []
+    }
+  }, 250)
+})
+
+watch(searchQuery, (newValue) => {
+  if (filterDebounceId) {
+    clearTimeout(filterDebounceId)
+  }
+
+  const trimmed = newValue.trim()
+
+  if (trimmed.length === 0) {
+    activeFilter.value = ''
+    return
+  }
+
+  filterDebounceId = setTimeout(() => {
+    activeFilter.value = trimmed
+  }, 1000)
+})
+
+const showSuggestions = computed(() => {
+  return (
+    isFocused.value &&
+    searchQuery.value.trim().length >= 2 &&
+    (searchLoading.value || suggestions.value.length > 0 || !!searchError.value)
+  )
+})
+
+const hasActiveFilter = computed(() => activeFilter.value.trim().length > 0)
+
+const handleFocus = () => {
+  if (blurTimeoutId) {
+    clearTimeout(blurTimeoutId)
+  }
+  isFocused.value = true
+}
+
+const handleBlur = () => {
+  blurTimeoutId = setTimeout(() => {
+    isFocused.value = false
+  }, 150)
+}
+
+const closeSuggestions = () => {
+  if (blurTimeoutId) {
+    clearTimeout(blurTimeoutId)
+  }
+  isFocused.value = false
+  suggestions.value = []
+}
+
+const applyFilterImmediately = () => {
+  if (filterDebounceId) {
+    clearTimeout(filterDebounceId)
+  }
+  activeFilter.value = searchQuery.value.trim()
+  closeSuggestions()
+}
+
+const clearQuery = () => {
+  searchQuery.value = ''
+  suggestions.value = []
+  activeFilter.value = ''
+}
+
+const clearFilter = () => {
+  activeFilter.value = ''
+  clearQuery()
+}
+
+const selectSuggestion = (option) => {
+  closeSuggestions()
+  searchQuery.value = ''
+
+  if (option.type === 'player') {
+    router.push(`/player/${option.id}`)
+    return
+  }
+
+  if (option.type === 'team') {
+    router.push(`/team/${option.id}`)
+  }
+}
+
+const formatSuggestionMeta = (option) => {
+  const base = option.type === 'player' ? 'Player' : option.type === 'team' ? 'Team' : ''
+  if (!option.subLabel) {
+    return base
+  }
+  return `${base} • ${option.subLabel}`
+}
+
+onBeforeUnmount(() => {
+  if (suggestionDebounceId) {
+    clearTimeout(suggestionDebounceId)
+  }
+  if (filterDebounceId) {
+    clearTimeout(filterDebounceId)
+  }
+  if (blurTimeoutId) {
+    clearTimeout(blurTimeoutId)
+  }
+})
 </script>
 
 <style scoped>
@@ -56,10 +245,12 @@ import CurrentSeasonDisplay from '../components/CurrentSeasonDisplay.vue'
 .header {
   display: flex;
   align-items: center;
-  padding: 0rem 1rem;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
   border-bottom: var(--color-border-thick) solid var(--color-border);
-  gap: 0;
+  gap: 2rem;
   background-color: var(--color-bg-card);
+  flex-wrap: wrap;
 }
 
 .title {
@@ -69,17 +260,163 @@ import CurrentSeasonDisplay from '../components/CurrentSeasonDisplay.vue'
   letter-spacing: 3px;
   text-transform: uppercase;
   margin: 0;
-  padding-right: 3rem;
+  padding-right: 2rem;
   border-right: var(--color-border-thick) solid var(--color-border);
   flex-shrink: 0;
 }
 
-.header :deep(.current-season-display) {
+.brand-block {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.brand-block :deep(.current-season-display) {
   margin-left: auto;
 }
 
+.search-area {
+  position: relative;
+  flex: 1;
+  max-width: 480px;
+  min-width: 260px;
+}
+
+.search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input-wrapper.active {
+  border-color: var(--color-text-secondary);
+  box-shadow: 0 0 0 4px rgba(255, 170, 0, 0.15);
+}
+
+.search-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+  padding: 0.35rem 0.25rem;
+  outline: none;
+}
+
+.search-input::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.clear-input {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+}
+
+.search-suggestions {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 0;
+  right: 0;
+  background-color: var(--color-bg-card);
+  border: 2px solid var(--color-border);
+  border-radius: 12px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.45);
+  z-index: 20;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 0.5rem 0;
+}
+
+.suggestion-state {
+  padding: 0.75rem 1rem;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.suggestion-error {
+  color: #f87171;
+}
+
+.suggestion-empty {
+  font-style: italic;
+}
+
+.suggestion-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.suggestion-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.6rem 1rem;
+  gap: 1rem;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.suggestion-item:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.suggestion-label {
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.suggestion-meta {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+}
+
+.filter-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background-color: rgba(255, 255, 255, 0.08);
+  border: 2px solid var(--color-border);
+  border-radius: 10px;
+  padding: 0.85rem 1.25rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.filter-banner strong {
+  color: var(--color-text-primary);
+}
+
+.filter-clear {
+  background: none;
+  border: 2px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-text-secondary);
+  padding: 0.3rem 0.9rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.filter-clear:hover {
+  background-color: var(--color-text-secondary);
+  color: var(--color-bg-primary);
+}
+
 .content-container {
-  padding: 5rem 2rem 2rem 2rem;
+  padding: 4rem 2rem 2rem 2rem;
 }
 
 .cards-grid {
@@ -103,12 +440,21 @@ import CurrentSeasonDisplay from '../components/CurrentSeasonDisplay.vue'
   .header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
-    padding: 1rem 1.5rem;
+    gap: 1.5rem;
+    padding: 1.5rem;
   }
 
   .title {
     font-size: 1.8rem;
+  }
+
+  .brand-block {
+    width: 100%;
+  }
+
+  .search-area {
+    width: 100%;
+    max-width: none;
   }
 
   .content-container {

--- a/frontend/src/views/PlayerPage.vue
+++ b/frontend/src/views/PlayerPage.vue
@@ -13,9 +13,51 @@
             />
             <div class="player-stats">
               <h1 class="player-name">{{ player?.firstName }} {{ player?.lastName }}</h1>
-              <p class="stat-line">Points: {{ player?.currentSeason?.points || 0 }}</p>
-              <p class="stat-line">Goals: {{ player?.currentSeason?.goals || 0 }}</p>
-              <p class="stat-line">Assists: {{ player?.currentSeason?.assists || 0 }}</p>
+              <p class="stat-line">Team: {{ player?.teamCode || 'N/A' }}</p>
+              <p class="stat-line">Points: {{ player?.points ?? 0 }}</p>
+              <p class="stat-line">Goals: {{ player?.goals ?? 0 }}</p>
+              <p class="stat-line">Assists: {{ player?.assists ?? 0 }}</p>
+              <p class="stat-line">Games Played: {{ player?.gamesPlayed ?? 0 }}</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h2 class="section-title">Season Snapshot</h2>
+          <div class="stats-grid">
+            <div class="stat-item">
+              <span class="stat-label">Points Per Game</span>
+              <span class="stat-value">{{ formatNumber(player?.pointsPerGame, 2) }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Plus/Minus</span>
+              <span class="stat-value">{{ player?.plusMinus ?? '0' }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Power Play Goals</span>
+              <span class="stat-value">{{ player?.powerPlayGoals ?? '0' }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Shots</span>
+              <span class="stat-value">{{ player?.shots ?? '0' }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Shooting %</span>
+              <span class="stat-value">{{ formatNumber(player?.shootingPercentage, 1) }}%</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Current Point Streak</span>
+              <span class="stat-value">{{ player?.currentPointStreak ?? 0 }} GP</span>
+            </div>
+            <div class="stat-item" v-if="player?.hotRating != null">
+              <span class="stat-label">Hot Rating (PPG last 3)</span>
+              <span class="stat-value">{{ formatNumber(player?.hotRating, 2) }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Hot Status</span>
+              <span class="stat-value" :class="{ positive: player?.hot, negative: player?.cold }">
+                {{ formatStreakStatus(player) }}
+              </span>
             </div>
           </div>
         </div>
@@ -35,19 +77,21 @@
             <thead>
               <tr>
                 <th>Date</th>
+                <th>Opponent</th>
+                <th>Location</th>
                 <th>Goals</th>
                 <th>Assists</th>
                 <th>Points</th>
-                <th>Time On Ice</th>
               </tr>
             </thead>
             <tbody>
-              <tr v-for="game in gameLogs" :key="game.gameId">
-                <td>{{ formatDate(game.date) }}</td>
+              <tr v-for="game in gameLogs" :key="game.gameNumber">
+                <td>{{ formatDate(game.gameDate) }}</td>
+                <td>{{ game.opponentTeamCode }}</td>
+                <td>{{ game.homeGame ? 'vs' : '@' }}</td>
                 <td>{{ game.goals }}</td>
                 <td>{{ game.assists }}</td>
                 <td>{{ game.points }}</td>
-                <td>{{ game.timeOnIce }}</td>
               </tr>
             </tbody>
           </table>
@@ -76,6 +120,20 @@ const formatDate = (dateString) => {
   if (!dateString) return 'N/A'
   const date = new Date(dateString)
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+const formatNumber = (value, decimals = 1) => {
+  if (value == null || Number.isNaN(value)) {
+    return '0.0'
+  }
+  return Number(value).toFixed(decimals)
+}
+
+const formatStreakStatus = (playerData) => {
+  if (!playerData) return 'Neutral'
+  if (playerData.hot) return 'Hot'
+  if (playerData.cold) return 'Cold'
+  return 'Neutral'
 }
 
 // Calculate previous season ID
@@ -182,6 +240,42 @@ onMounted(async () => {
   font-weight: 700;
   margin-bottom: 1rem;
   text-align: center;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.stat-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.stat-value.positive {
+  color: #4ade80;
+}
+
+.stat-value.negative {
+  color: #f87171;
 }
 
 .chart-placeholder {

--- a/frontend/src/views/TeamPage.vue
+++ b/frontend/src/views/TeamPage.vue
@@ -14,9 +14,52 @@
             />
             <div class="team-stats">
               <h1 class="team-name">{{ team?.teamName }}</h1>
-              <p class="stat-line">Wins: {{ team?.currentSeason?.wins || 0 }}</p>
-              <p class="stat-line">Losses: {{ team?.currentSeason?.losses || 0 }}</p>
-              <p class="stat-line">Points: {{ team?.currentSeason?.points || 0 }}</p>
+              <p class="stat-line">Conference: {{ team?.conferenceName || 'N/A' }}</p>
+              <p class="stat-line">Division: {{ team?.divisionName || 'N/A' }}</p>
+              <p class="stat-line">Record: {{ formatRecord(team) }}</p>
+              <p class="stat-line">Points: {{ team?.points ?? 0 }}</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="section">
+          <h2 class="section-title">Season Snapshot</h2>
+          <div class="stats-grid">
+            <div class="stat-item">
+              <span class="stat-label">Games Played</span>
+              <span class="stat-value">{{ team?.gamesPlayed ?? 0 }}</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Goal Differential</span>
+              <span class="stat-value" :class="diffClass(team?.goalDifferential)">
+                {{ formatGoalDifferential(team?.goalDifferential) }}
+              </span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Point %</span>
+              <span class="stat-value">{{ formatPercentage(team?.pointPercentage) }}%</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Last 10 Win %</span>
+              <span class="stat-value">{{ formatPercentage(team?.last10GamesWinPercentage) }}%</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Current Win Streak</span>
+              <span class="stat-value">{{ team?.currentWinStreak ?? 0 }} GP</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Current Loss Streak</span>
+              <span class="stat-value">{{ team?.currentLossStreak ?? 0 }} GP</span>
+            </div>
+            <div class="stat-item">
+              <span class="stat-label">Hot Status</span>
+              <span class="stat-value" :class="{ positive: team?.hot, negative: team?.cold }">
+                {{ formatStreakStatus(team) }}
+              </span>
+            </div>
+            <div class="stat-item" v-if="team?.nextOpponentCode">
+              <span class="stat-label">Next Game</span>
+              <span class="stat-value">{{ formatNextGame(team) }}</span>
             </div>
           </div>
         </div>
@@ -25,20 +68,20 @@
           <h2 class="section-title">Team Statistics</h2>
           <div class="stats-grid">
             <div class="stat-item">
-              <span class="stat-label">Goals Per Game:</span>
-              <span class="stat-value">{{ team?.currentSeason?.goalsPerGame?.toFixed(2) || '0.00' }}</span>
+              <span class="stat-label">Goals For</span>
+              <span class="stat-value">{{ team?.goalsFor ?? 0 }}</span>
             </div>
             <div class="stat-item">
-              <span class="stat-label">Goals Against Per Game:</span>
-              <span class="stat-value">{{ team?.currentSeason?.goalsAgainstPerGame?.toFixed(2) || '0.00' }}</span>
+              <span class="stat-label">Goals Against</span>
+              <span class="stat-value">{{ team?.goalsAgainst ?? 0 }}</span>
             </div>
             <div class="stat-item">
-              <span class="stat-label">Power Play %:</span>
-              <span class="stat-value">{{ team?.currentSeason?.powerPlayPercentage?.toFixed(1) || '0.0' }}%</span>
+              <span class="stat-label">Overtime Losses</span>
+              <span class="stat-value">{{ team?.overtimeLosses ?? 0 }}</span>
             </div>
             <div class="stat-item">
-              <span class="stat-label">Penalty Kill %:</span>
-              <span class="stat-value">{{ team?.currentSeason?.penaltyKillPercentage?.toFixed(1) || '0.0' }}%</span>
+              <span class="stat-label">Last Updated</span>
+              <span class="stat-value">{{ formatDate(team?.lastUpdated) }}</span>
             </div>
           </div>
         </div>
@@ -73,6 +116,53 @@ const { loading, error, getTeamDetails, getTeamGameLog } = useTeamStats()
 const team = ref(null)
 const teamGameLogs = ref([])
 const previousSeasonTeamGameLogs = ref([])
+
+const formatRecord = (teamData) => {
+  if (!teamData) return '0-0-0'
+  const wins = teamData.wins ?? 0
+  const losses = teamData.losses ?? 0
+  const ot = teamData.overtimeLosses ?? 0
+  return `${wins}-${losses}-${ot}`
+}
+
+const formatGoalDifferential = (diff) => {
+  if (diff == null) return '0'
+  return diff > 0 ? `+${diff}` : diff.toString()
+}
+
+const diffClass = (diff) => {
+  if (diff == null || diff === 0) return ''
+  return diff > 0 ? 'positive' : 'negative'
+}
+
+const formatPercentage = (value) => {
+  if (value == null) return '0.0'
+  return (Number(value) * 100).toFixed(1)
+}
+
+const formatDate = (dateString) => {
+  if (!dateString) return 'N/A'
+  const date = new Date(dateString)
+  if (Number.isNaN(date.getTime())) {
+    return dateString
+  }
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+const formatNextGame = (teamData) => {
+  if (!teamData || !teamData.nextOpponentCode) return 'TBD'
+  const location = teamData.nextGameIsHome ? 'vs' : '@'
+  const date = teamData.nextGameDate ? formatDate(teamData.nextGameDate) : ''
+  return `${location} ${teamData.nextOpponentCode}${date ? ` • ${date}` : ''}`
+}
+
+const formatStreakStatus = (teamData) => {
+  if (!teamData) return 'Neutral'
+  if (teamData.hot) return 'Hot'
+  if (teamData.cold) return 'Cold'
+  if (teamData.pointStreak) return 'Point Streak'
+  return 'Neutral'
+}
 
 // Calculate previous season ID
 const calculatePreviousSeason = () => {
@@ -162,6 +252,42 @@ onMounted(async () => {
   margin: 0.5rem 0;
 }
 
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background-color: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.stat-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.stat-value.positive {
+  color: #4ade80;
+}
+
+.stat-value.negative {
+  color: #f87171;
+}
+
 .section {
   background-color: var(--color-bg-card);
   border-radius: 8px;
@@ -176,33 +302,10 @@ onMounted(async () => {
   text-align: center;
 }
 
-.stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-}
-
-.stat-item {
-  display: flex;
-  justify-content: space-between;
-  padding: 1rem;
-  background-color: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-}
-
-.stat-label {
-  font-weight: 600;
-}
-
-.stat-value {
-  font-weight: 700;
-  font-size: 1.2rem;
-}
-
 .placeholder-text {
   text-align: center;
   padding: 2rem;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--color-text-secondary);
 }
 
 .loading,


### PR DESCRIPTION
## Summary
- add a global search endpoint that queries players and teams from the database and expose it via a dedicated controller
- document the search API contract and wire repositories/services to return shared search result DTOs
- build a home page autocomplete with enter-to-filter behavior, suggestion rendering, and filter messaging
- debounce the home page search filter so dashboard cards update automatically one second after typing stops

## Testing
- npm run build --prefix frontend *(fails: missing vue-chartjs dependency in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf8d6272483229567ab830f90892f