### PR TITLE
feat: implement mobile UI layout (closes #5)

### DIFF
--- a/frontend/src/views/HomePage.vue
+++ b/frontend/src/views/HomePage.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="home-page">
-    <div class="header">
+    <!-- Desktop header -->
+    <div class="header desktop-header">
       <h1 class="title">WHOS HOT NHL</h1>
       <div class="search-container">
         <SearchBar />
@@ -8,9 +9,17 @@
       <CurrentSeasonDisplay />
     </div>
 
-    <div class="content-container">
+    <!-- Mobile header: logo above search bar, both centered -->
+    <div class="header mobile-header">
+      <img src="../assets/nhl_logo.png" alt="NHL Logo" class="mobile-logo" />
+      <div class="search-container">
+        <SearchBar />
+      </div>
+    </div>
+
+    <!-- Desktop: grid of cards -->
+    <div class="content-container desktop-content">
       <div class="cards-grid">
-        <!-- Favorites Card - Only show if user has favorites -->
         <ExpandableCard v-if="showFavorites" title="My Favorites" :defaultExpanded="true" class="favorites-card">
           <FavoritesTable />
         </ExpandableCard>
@@ -41,13 +50,40 @@
       </div>
     </div>
 
+    <!-- Mobile: swipeable cards (one at a time) -->
+    <div class="content-container mobile-content">
+      <div
+        class="swipe-container"
+        ref="swipeContainer"
+        @touchstart="onTouchStart"
+        @touchmove="onTouchMove"
+        @touchend="onTouchEnd"
+      >
+        <div class="swipe-track" :style="{ transform: `translateX(${swipeOffset}px)` }">
+          <div v-for="(card, index) in mobileCards" :key="card.key" class="swipe-slide">
+            <ExpandableCard :title="card.title" :class="{ 'favorites-card': card.key === 'favorites' }">
+              <component :is="card.component" />
+            </ExpandableCard>
+          </div>
+        </div>
+      </div>
+      <div class="swipe-dots">
+        <span
+          v-for="(card, index) in mobileCards"
+          :key="card.key"
+          :class="['dot', { active: index === activeCardIndex }]"
+          @click="goToCard(index)"
+        ></span>
+      </div>
+    </div>
+
     <!-- Cookie Consent Banner -->
     <CookieConsent />
   </div>
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, onUnmounted, nextTick, watch, shallowRef } from 'vue'
 import ExpandableCard from '../components/ExpandableCard.vue'
 import TopPointsTable from '../components/TopPointsTable.vue'
 import PointStreaksTable from '../components/PointStreaksTable.vue'
@@ -66,9 +102,81 @@ const { initializeFavorites, favoritesCount } = useFavorites()
 // Show favorites card only if user has favorites
 const showFavorites = computed(() => favoritesCount.value > 0)
 
+// Mobile swipe state
+const activeCardIndex = ref(0)
+const swipeContainer = ref(null)
+const touchStartX = ref(0)
+const touchCurrentX = ref(0)
+const isSwiping = ref(false)
+const slideWidth = ref(0)
+
+const mobileCards = computed(() => {
+  const cards = []
+  if (showFavorites.value) {
+    cards.push({ key: 'favorites', title: 'My Favorites', component: FavoritesTable })
+  }
+  cards.push(
+    { key: 'standings', title: 'Player standings', component: TopPointsTable },
+    { key: 'streaks', title: 'Point streaks', component: PointStreaksTable },
+    { key: 'hot-players', title: 'Last 10 games', component: HottestPlayersTable },
+    { key: 'team-standings', title: 'Team standings', component: TeamStandingsTable },
+    { key: 'win-streaks', title: 'Win streaks', component: TeamWinStreaksTable },
+    { key: 'team-hot', title: 'Last 10 games', component: TeamHotTable }
+  )
+  return cards
+})
+
+const swipeOffset = computed(() => {
+  const base = -(activeCardIndex.value * slideWidth.value)
+  if (isSwiping.value) {
+    return base + (touchCurrentX.value - touchStartX.value)
+  }
+  return base
+})
+
+const updateSlideWidth = () => {
+  if (swipeContainer.value) {
+    slideWidth.value = swipeContainer.value.offsetWidth
+  }
+}
+
+const onTouchStart = (e) => {
+  touchStartX.value = e.touches[0].clientX
+  touchCurrentX.value = e.touches[0].clientX
+  isSwiping.value = true
+}
+
+const onTouchMove = (e) => {
+  if (!isSwiping.value) return
+  touchCurrentX.value = e.touches[0].clientX
+}
+
+const onTouchEnd = () => {
+  if (!isSwiping.value) return
+  isSwiping.value = false
+  const diff = touchCurrentX.value - touchStartX.value
+  const threshold = slideWidth.value * 0.2
+
+  if (diff < -threshold && activeCardIndex.value < mobileCards.value.length - 1) {
+    activeCardIndex.value++
+  } else if (diff > threshold && activeCardIndex.value > 0) {
+    activeCardIndex.value--
+  }
+}
+
+const goToCard = (index) => {
+  activeCardIndex.value = index
+}
+
 // Initialize favorites on mount
 onMounted(() => {
   initializeFavorites()
+  nextTick(updateSlideWidth)
+  window.addEventListener('resize', updateSlideWidth)
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateSlideWidth)
 })
 </script>
 
@@ -79,13 +187,30 @@ onMounted(() => {
   background-color: var(--color-bg-primary);
 }
 
+/* Header base styles */
 .header {
+  border-bottom: var(--color-border-thick) solid var(--color-border);
+  background-color: var(--color-bg-card);
+}
+
+.desktop-header {
   display: flex;
   align-items: center;
   padding: 0rem 1rem;
-  border-bottom: var(--color-border-thick) solid var(--color-border);
   gap: 2rem;
-  background-color: var(--color-bg-card);
+}
+
+.mobile-header {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  gap: 1rem;
+}
+
+.mobile-logo {
+  width: 80px;
+  height: auto;
 }
 
 .title {
@@ -105,7 +230,7 @@ onMounted(() => {
   max-width: 500px;
 }
 
-.header :deep(.current-season-display) {
+.desktop-header :deep(.current-season-display) {
   margin-left: auto;
 }
 
@@ -128,6 +253,56 @@ onMounted(() => {
   min-height: 700px;
 }
 
+/* Mobile content hidden on desktop */
+.mobile-content {
+  display: none;
+}
+
+/* Swipe carousel styles */
+.swipe-container {
+  overflow: hidden;
+  width: 100%;
+  position: relative;
+}
+
+.swipe-track {
+  display: flex;
+  transition: transform 0.3s ease;
+  will-change: transform;
+}
+
+.swipe-slide {
+  min-width: 100%;
+  flex-shrink: 0;
+  padding: 0 0.5rem;
+  box-sizing: border-box;
+}
+
+.swipe-slide :deep(.expandable-card) {
+  height: auto;
+  min-height: 400px;
+}
+
+.swipe-dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 0;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.dot.active {
+  background-color: var(--color-text-secondary);
+}
+
 @media (max-width: 1200px) {
   .cards-grid {
     grid-template-columns: repeat(2, 1fr);
@@ -135,7 +310,7 @@ onMounted(() => {
 }
 
 @media (max-width: 1024px) {
-  .header {
+  .desktop-header {
     flex-wrap: wrap;
   }
 
@@ -147,30 +322,27 @@ onMounted(() => {
 }
 
 @media (max-width: 768px) {
-  .header {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 1rem 1.5rem;
+  /* Switch to mobile layout */
+  .desktop-header {
+    display: none;
   }
 
-  .title {
-    font-size: 1.8rem;
-    border-right: none;
-    padding-right: 0;
+  .mobile-header {
+    display: flex;
   }
 
-  .search-container {
+  .mobile-header .search-container {
     width: 100%;
+    max-width: 100%;
   }
 
-  .content-container {
-    padding: 1.5rem;
+  .desktop-content {
+    display: none;
   }
 
-  .cards-grid {
-    grid-template-columns: 1fr;
-    gap: 1rem;
+  .mobile-content {
+    display: block;
+    padding: 1rem 0.5rem;
   }
 }
 </style>

--- a/frontend/src/views/PlayerPage.vue
+++ b/frontend/src/views/PlayerPage.vue
@@ -232,9 +232,31 @@ onMounted(async () => {
 }
 
 @media (max-width: 768px) {
+  .container {
+    padding: 0 1rem;
+  }
+
   .player-info-card {
     flex-direction: column;
     text-align: center;
+    padding: 1.5rem 1rem;
+  }
+
+  .player-name {
+    font-size: 1.5rem;
+  }
+
+  .section-title {
+    font-size: 1.2rem;
+  }
+
+  .game-log-table {
+    font-size: 0.85rem;
+  }
+
+  .game-log-table th,
+  .game-log-table td {
+    padding: 0.5rem 0.35rem;
   }
 }
 </style>

--- a/frontend/src/views/TeamPage.vue
+++ b/frontend/src/views/TeamPage.vue
@@ -217,13 +217,51 @@ onMounted(async () => {
 }
 
 @media (max-width: 768px) {
+  .container {
+    padding: 0 1rem;
+  }
+
   .team-info-card {
     flex-direction: column;
     text-align: center;
+    padding: 1.5rem 1rem;
+  }
+
+  .team-name {
+    font-size: 1.5rem;
+  }
+
+  .section-title {
+    font-size: 1.2rem;
   }
 
   .stats-grid {
     grid-template-columns: 1fr;
+  }
+
+  /* Reorder sections on mobile: image -> graph -> stats -> roster */
+  .team-content {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .team-header {
+    order: 1;
+  }
+
+  .section:nth-child(3) {
+    /* Win/Loss Progression graph */
+    order: 2;
+  }
+
+  .section:nth-child(2) {
+    /* Team Statistics */
+    order: 3;
+  }
+
+  .section:nth-child(4) {
+    /* Roster */
+    order: 4;
   }
 }
 </style>


### PR DESCRIPTION
- HomePage: centered logo above search bar on mobile, swipeable card carousel showing one table at a time with touch gestures and dot indicators
- PlayerPage: stacked layout with image on top, graph below, game log table at bottom, improved mobile spacing
- TeamPage: reordered sections on mobile so graph appears directly under team image, improved mobile spacing

https://claude.ai/code/session_0145f11CQvkXfDdQLV6zy69g